### PR TITLE
article URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ This repository serves the compiled static files via GitHub Pages. To deploy upd
 2. Copy the generated `dist/` contents into this repository.
 3. Commit and push to the `main` branch. GitHub Pages will automatically serve the updated site at `https://kachowska.github.io`.
 
+
+### Sitemap
+
+Run `./update-sitemap.sh` after copying new build outputs into this repository to regenerate `sitemap.xml` with all article pages. The `robots.txt` file points to this sitemap so search engines can discover new pages.
+

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
+
 Sitemap: https://kachowska.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://kachowska.github.io/</loc></url>
-  <url><loc>https://kachowska.github.io/#articles</loc></url>
+  <url><loc>https://kachowska.github.io/articles/area</loc></url>
+  <url><loc>https://kachowska.github.io/articles/correlation</loc></url>
+  <url><loc>https://kachowska.github.io/articles/listings</loc></url>
+  <url><loc>https://kachowska.github.io/articles/median</loc></url>
+  <url><loc>https://kachowska.github.io/articles/olist</loc></url>
+  <url><loc>https://kachowska.github.io/articles/original</loc></url>
+  <url><loc>https://kachowska.github.io/articles/price</loc></url>
 </urlset>

--- a/update-sitemap.sh
+++ b/update-sitemap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="https://kachowska.github.io"
+
+urls=("$BASE_URL/")
+
+# Extract article routes from bundled assets
+routes=$(rg -o "/articles/[a-zA-Z0-9\-]+" -N assets/index-*.js | cut -d: -f2 | sort -u)
+
+for route in $routes; do
+  urls+=("$BASE_URL$route")
+done
+
+{
+  echo '<?xml version="1.0" encoding="UTF-8"?>'
+  echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+  for url in "${urls[@]}"; do
+    echo "  <url><loc>$url</loc></url>"
+  done
+  echo '</urlset>'
+} > sitemap.xml


### PR DESCRIPTION
## Summary
- add script to rebuild sitemap from bundled assets
- list each article route in sitemap.xml
- ensure robots.txt references the sitemap

## Testing
- `npm test` *(fails: Could not read package.json)*

